### PR TITLE
Fix response image dimensions

### DIFF
--- a/client/components/Response.jsx
+++ b/client/components/Response.jsx
@@ -33,7 +33,9 @@ const ProfilePic = styled.img`
 const Response = (props) => {
   return (
     <StyledResponse>
-      <ProfilePic src={props.url}></ProfilePic>
+      <div>
+        <ProfilePic src={props.url}></ProfilePic>
+      </div>
       <div>
         <ResponseName>Response from {props.name}:</ResponseName>
         <ResponseBody>{props.body}</ResponseBody>


### PR DESCRIPTION
If merged, this pull request will:
- [Ensure response images are loaded with proper dimensions](https://trello.com/c/fldTHfov)